### PR TITLE
Adding functionality to select if complete deploy, plus update versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.509.4</version>
+		<version>1.609.1</version>
 	</parent>
 
 	<groupId>org.jenkins-ci.plugins</groupId>
 	<artifactId>mule-mmc</artifactId>
-	<version>2.0-SNAPSHOT</version>
+	<version>2.1-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 
 	<!-- get every artifact through repo.jenkins-ci.org, which proxies all the 
@@ -52,11 +52,12 @@
 		<dependency>
 			<groupId>org.jenkins-ci.main</groupId>
 			<artifactId>maven-plugin</artifactId>
+			<version>2.12</version>
 		</dependency>
 
 
 	</dependencies>
 	<properties>
-		<maven-hpi-plugin.version>1.95</maven-hpi-plugin.version>
+		<maven-hpi-plugin.version>1.115</maven-hpi-plugin.version>
 	</properties>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/mulemmc/MMCDeployerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/mulemmc/MMCDeployerBuilder.java
@@ -101,7 +101,11 @@ public class MMCDeployerBuilder extends Builder
 								listener.getLogger().println(">>>>>>>>>>>> ARTIFACT ID: " + nextAttached.artifactId);
 								listener.getLogger().println(">>>>>>>>>>>> VERSION: " + nextAttached.version);
 								listener.getLogger().println(">>>>>>>>>>>> FILE: " + nextAttached.getFile(mavenBuild).getAbsolutePath());
-								doDeploy(listener, muleRest, nextAttached.getFile(mavenBuild), nextAttached.version,
+								doDeploy(listener, 
+										muleRest, 
+										nextAttached.getFile(mavenBuild), 
+										hudson.Util.replaceMacro(clusterOrServerGroupName, envVars), 
+										nextAttached.version,
 								        nextAttached.artifactId);
 								success = true;
 							}
@@ -119,8 +123,13 @@ public class MMCDeployerBuilder extends Builder
 						listener.getLogger().println(">>>>>>>>>>>> ARTIFACT ID: " + hudson.Util.replaceMacro(artifactName, envVars));
 						listener.getLogger().println(">>>>>>>>>>>> VERSION: " +hudson.Util.replaceMacro(artifactVersion, envVars));
 						listener.getLogger().println(">>>>>>>>>>>> FILE: "+ file.getRemote());
+						listener.getLogger().println(">>>>>>>>>>>> SERVER: " +hudson.Util.replaceMacro(clusterOrServerGroupName, envVars));
 						
-						doDeploy(listener, muleRest, new File(file.getRemote()), hudson.Util.replaceMacro(artifactVersion, envVars),
+						doDeploy(listener, 
+								muleRest, 
+								new File(file.getRemote()), 
+								hudson.Util.replaceMacro(clusterOrServerGroupName, envVars), 
+								hudson.Util.replaceMacro(artifactVersion, envVars),
 						        hudson.Util.replaceMacro(artifactName, envVars));
 						success = true;
 					}
@@ -148,7 +157,7 @@ public class MMCDeployerBuilder extends Builder
 		return success;
 	}
 
-	private void doDeploy(BuildListener listener, MuleRest muleRest, File aFile, String theVersion, String theName) throws Exception
+	private void doDeploy(BuildListener listener, MuleRest muleRest, File aFile, String clusterOrServerGroupName, String theVersion, String theName) throws Exception
 	{
 		listener.getLogger().println("Deployment starting...");
 		String versionId = muleRest.restfullyUploadRepository(theName, theVersion, aFile);

--- a/src/main/java/org/jenkinsci/plugins/mulemmc/MMCDeployerBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/mulemmc/MMCDeployerBuilder.java
@@ -41,11 +41,12 @@ public class MMCDeployerBuilder extends Builder
 	public final String artifactVersion;
 	public final String artifactName;
 	public final boolean clusterDeploy;
+	public final boolean completeDeployment;
 	public final String clusterOrServerGroupName;
 	public final boolean deployWithPomDetails;
 
 	@DataBoundConstructor
-	public MMCDeployerBuilder(String mmcUrl, String user, String password, boolean clusterDeploy, String clusterOrServerGroupName,
+	public MMCDeployerBuilder(String mmcUrl, String user, String password, boolean clusterDeploy, boolean completeDeployment, String clusterOrServerGroupName,
 	        String fileLocation, String artifactName, String artifactVersion) {
 		this.mmcUrl = mmcUrl;
 		this.user = user;
@@ -55,6 +56,7 @@ public class MMCDeployerBuilder extends Builder
 		this.artifactVersion = artifactVersion;
 		this.clusterOrServerGroupName = clusterOrServerGroupName;
 		this.clusterDeploy = clusterDeploy;
+		this.completeDeployment = completeDeployment;
 		this.deployWithPomDetails = true;
 	}
 
@@ -162,7 +164,9 @@ public class MMCDeployerBuilder extends Builder
 			deploymentId = muleRest.restfullyCreateDeployment(clusterOrServerGroupName, theName, versionId);
 
 		}
-		muleRest.restfullyDeployDeploymentById(deploymentId);
+		if(completeDeployment){
+			muleRest.restfullyDeployDeploymentById(deploymentId);
+		}
 		listener.getLogger().println("Deployment finished");
 	}
 

--- a/src/main/java/org/jenkinsci/plugins/mulemmc/MuleRest.java
+++ b/src/main/java/org/jenkinsci/plugins/mulemmc/MuleRest.java
@@ -323,11 +323,14 @@ public class MuleRest
 
 		int statusCode = httpClient.executeMethod(post);
 
+		//in the case of a conflict status code, use the pre-existing application
 		if (statusCode != Status.CONFLICT.getStatusCode()) {
 			processResponseCode(statusCode);
 
 		} else{
 			logger.info("ARTIFACT ALREADY EXISTS in MMC. Creating Deployment using Pre-Existing Artifact (Not-Overwriting)");
+			post.releaseConnection();
+			return restfullyGetApplicationId(name, version);
 		}
 
 		String responseObject = post.getResponseBodyAsString();

--- a/src/main/java/org/jenkinsci/plugins/mulemmc/MuleRest.java
+++ b/src/main/java/org/jenkinsci/plugins/mulemmc/MuleRest.java
@@ -323,7 +323,12 @@ public class MuleRest
 
 		int statusCode = httpClient.executeMethod(post);
 
-		processResponseCode(statusCode);
+		if (statusCode != Status.CONFLICT.getStatusCode()) {
+			processResponseCode(statusCode);
+
+		} else{
+			logger.info("ARTIFACT ALREADY EXISTS in MMC. Creating Deployment using Pre-Existing Artifact (Not-Overwriting)");
+		}
 
 		String responseObject = post.getResponseBodyAsString();
 		post.releaseConnection();
@@ -415,7 +420,7 @@ public class MuleRest
 		post.setRequestEntity(new StringRequestEntity(stringWriter.toString(), "application/json", null));
 
 		logger.fine(">>>>restfullyCreateClusterDeploymentById request " + stringWriter.toString());
-		
+
 		int statusCode = httpClient.executeMethod(post);
 
 		processResponseCode(statusCode);

--- a/src/main/resources/org/jenkinsci/plugins/mulemmc/MMCDeployerBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/mulemmc/MMCDeployerBuilder/config.jelly
@@ -43,5 +43,10 @@
     <f:entry title="Is Cluster" field="clusterDeploy" description="Is cluster">
         <f:checkbox />
     </f:entry>
+
+    <f:entry title="Deploy After Upload" field="completeDeployment" description="If True the plugin will attempt to activate the deployment after upload is complete">
+        <f:checkbox />
+    </f:entry>
+
   </f:section>
 </j:jelly>


### PR DESCRIPTION
I updated all the versions in this plugin POM file to conform with newer stuff.  
Fixed the jffi dependency (seems to no longer complain)

**Added Functionality:**
1) This now has a checkbox to see if the user wants to complete the deployment.  I have found that in working with MMC I often just want to create the repo entry, and create the deployment, but not hit deploy until I get to MMC and make sure everything is ok.  
2) If there is already an artifact in place with the exact version it will create the deployment with the existing artifact.  SNAPSHOT versions are still overwritten by default. Released version will use the version inside MMC already.  I found the deploy script failed sometimes for various reasons and I wanted to re-run it to create the deployment but then it would fail because the artifact was already there.  On releases it's totally fine to have it use the artifact in place already.  

These two enhancements make the plugin much easier and user friendly.  
